### PR TITLE
fix css to display disabled buttons correctly

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -74,13 +74,6 @@ input[type='email'] {
   padding: 5px 10px;
 }
 
-.Button[disabled],
-button[disabled] {
-  background-color: $color-grayLightest;
-  border-color: $color-grayLight;
-  color: $color-grayDark;
-}
-
 .Button,
 button {
   border: 0 none;
@@ -101,8 +94,8 @@ button.primary {
   background-color: $color-red;
   color: $color-white;
 }
-.Button.primary:hover,
-button.primary:hover {
+.Button.primary:not([disabled]):hover,
+button.primary:not([disabled]):hover {
   background-color: $color-redDark;
 }
 .Button.large,
@@ -115,6 +108,13 @@ button.transparent {
   background-color: transparent;
   border-color: $color-white;
   color: $color-white;
+}
+
+.Button[disabled],
+button[disabled] {
+  background-color: $color-grayLightest;
+  border-color: $color-grayLight;
+  color: $color-grayDark;
 }
 
 input[type='text'],


### PR DESCRIPTION
currently it's hard for the user to find what tickets are available as all of the buttons are red, even the ones that are disabled (i.e. sold out). there was CSS to display disabled buttons as grayed out, but it was not setup correctly.

## Before

![image](https://user-images.githubusercontent.com/887639/56844278-b9dc4f00-687b-11e9-99fb-e360b5278311.png)

## After

![image](https://user-images.githubusercontent.com/887639/56844272-9dd8ad80-687b-11e9-87db-da5c4efc52e3.png)
