### PR TITLE
Accessibility tweaks for main pages

### DIFF
--- a/app/components/Avatar.js
+++ b/app/components/Avatar.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default (props) => {
   let size = props.size || 200
   return (
-    <img src={props.url} className="Avatar" style={{
+    <img src={props.url} alt="" className="Avatar" style={{
       width: size,
       height: size,
       borderRadius: size / 2

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -36,7 +36,7 @@ const HomeHeader = () => {
   return (
     <div className="Home__Header">
       <div className="Home__Header__Wrapper">
-        <img src="assets/dist/img/ReactLogo.svg" width="100" height="100" />
+        <img src="assets/dist/img/ReactLogo.svg" alt="React logo." width="100" height="100" />
         <div className="Home__Header__Content">
           <h1>React Rally</h1>
           <h2>{CONF_DATES_DISPLAY}</h2>
@@ -106,8 +106,8 @@ const Navigation = ({ onMenuClick = () => {} }) => {
   return (
     <div className="Header__Nav">
       <section className="Header__Nav__Menu">
-        <Link to="/" id="logo" onClick={() => onMenuClick(false)}>
-          <img src="assets/dist/img/ReactLogo.svg" width="44" height="44" />
+        <Link to="/" id="logo" aria-label="Home" onClick={() => onMenuClick(false)}>
+          <img src="assets/dist/img/ReactLogo.svg" alt="React logo." width="44" height="44" />
         </Link>
         <ul>
           <li>

--- a/app/components/Icon.js
+++ b/app/components/Icon.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default (props) => {
   return (
-    <a href={props.href} target="_blank" className={`Icon Icon--${props.type}`}>
+    <a href={props.href} aria-label={props.type} target="_blank" className={`Icon Icon--${props.type}`}>
       <i className={`fa fa-${props.type}`}/>
     </a>
   )

--- a/app/components/Person.js
+++ b/app/components/Person.js
@@ -5,7 +5,7 @@ import Icon from 'components/Icon'
 export default (props) => {
   return (
     <div className="Person">
-      <Avatar url={props.avatar} size={200}/>
+      <Avatar url={props.avatar} name={props.name} size={200}/>
       <b>{props.name}</b><br/>
       <em>{props.title}</em>
       <div className="Person__Social">

--- a/app/screens/Home/index.js
+++ b/app/screens/Home/index.js
@@ -25,7 +25,7 @@ const UpcomingDate = ({timestamp, description}) => {
         Home__UpcomingDate: true,
         'Home__UpcomingDate--disabled': isAfter,
       })}>
-      <img src={iconSource} />
+      <img alt="" src={iconSource} />
       <div>
         <time>{date.format('MMMM D, YYYY')}</time>
         <small>{description}</small>
@@ -45,7 +45,9 @@ const TicketCard = ({name, description, price, soldOut}) => {
         <p>{description}</p>
       </div>
       <div className="Home__TicketCard__Order">
-        <h2>{isNaN(price) ? '' : '$' + price}</h2>
+        {!isNaN(price) && (
+          <h2>{`$${price}`}</h2>
+        )}
         <Button
           className="primary"
           href={constants.Links.TICKET_SALES}

--- a/app/screens/Venue/index.js
+++ b/app/screens/Venue/index.js
@@ -14,8 +14,8 @@ export default () => {
         </h2>
         <div className="Venue__Details">
           <div className="Venue__Details__Mapbox">
-            <a href={constants.Links.VENUE_DIRECTIONS} target="_blank">
-              <img src="assets/dist/img/Sheraton_Map.png" width="400" />
+            <a href={constants.Links.VENUE_DIRECTIONS} aria-label="Map directions to venue." target="_blank">
+              <img src="assets/dist/img/Sheraton_Map.png" alt="" width="400" />
             </a>
             <div className="Venue__Details__Mapbox__Address">
               <strong>Sheraton Salt Lake City Hotel</strong>
@@ -53,8 +53,8 @@ export default () => {
         <h2>The Afterparty</h2>
         <div className="Venue__Details">
           <div className="Venue__Details__Mapbox">
-            <a href={constants.Links.PARTY_DIRECTIONS} target="_blank">
-              <img src="assets/dist/img/Gateway_Map.png" width="400" />
+            <a href={constants.Links.PARTY_DIRECTIONS} aria-label="Map directions to after party." target="_blank">
+              <img src="assets/dist/img/Gateway_Map.png" alt="" width="400" />
             </a>
             <div className="Venue__Details__Mapbox__Address">
               <strong>The Gateway</strong>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -114,7 +114,7 @@ button.transparent {
 button[disabled] {
   background-color: $color-grayLightest;
   border-color: $color-grayLight;
-  color: $color-grayDark;
+  color: $color-grayDarkest;
 }
 
 input[type='text'],
@@ -264,7 +264,7 @@ input[type='email'] {
   margin: 25px 0;
 }
 .Home__UpcomingDate--disabled {
-  color: $color-gray;
+  color: $color-grayDarkest;
 }
 .Home__UpcomingDate--disabled time {
   text-decoration: line-through;
@@ -278,7 +278,7 @@ input[type='email'] {
   display: block;
 }
 .Home__UpcomingDate small {
-  font-size: $size-font-small;
+  font-size: $size-font-medium;
 }
 
 .Home__TicketCard {
@@ -478,7 +478,7 @@ input[type='email'] {
 
 /* -- Header -- */
 .Header {
-  background-color: $color-tealLight;
+  background-color: $color-teal;
 }
 .Header__Home {
   background: url(../dist/img/TimpanogosHeader.png) no-repeat center -100px fixed;
@@ -590,9 +590,9 @@ input[type='email'] {
 /* -- Footer -- */
 
 .Footer {
-  color: $color-grayDark;
+  color: $color-grayDarkest;
   background-color: $color-grayLightest;
-  font-size: 0.7em;
+  font-size: 0.8em;
   padding: 50px;
 }
 .Footer__Grid {
@@ -641,7 +641,7 @@ section.Footer__Tickets h2 {
   font-size: $size-font-medium;
 }
 .Person em {
-  color: $color-grayDark;
+  color: $color-grayDarkest;
   display: inline-block;
   font-size: $size-font-small;
   height: 45px;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>React Rally</title>
     <meta charset="utf-8" />


### PR DESCRIPTION
Happy Global Accessibility Awareness Day!

I addressed any errors surfaced by axe on the homepage and main pages, and did some basic keyboard testing.

<img width="1680" alt="Screen Shot 2019-05-16 at 8 16 14 PM" src="https://user-images.githubusercontent.com/3461087/57896672-860b9e00-7817-11e9-8b23-133f047d6a05.png">

Suggestion to darken the homepage image to improve that color contrast. Technically it won't get caught because of the background image.

Cheers!